### PR TITLE
fixes to load libfcgi on Mac OS

### DIFF
--- a/cl-fastcgi.lisp
+++ b/cl-fastcgi.lisp
@@ -15,7 +15,8 @@
       "libfcgi already loaded!"
       (progn
         (define-foreign-library libfcgi
-            (:unix (:or path "libfcgi.so"))
+          (:darwin (:or path "libfcgi.dylib"))
+          (:unix (:or path "libfcgi.so"))
           (:t (:default "libfcgi")))
         (use-foreign-library libfcgi)
         (setf *libfcgi-loaded* t))))


### PR DESCRIPTION
cl-fastcgi cannot load with Clozure CL on Mac OS. Here's an error on loading it.

```
Unable to load any of the alternatives:
   (CL-FASTCGI::PATH "libfcgi.so")
   [Condition of type CFFI:LOAD-FOREIGN-LIBRARY-ERROR]
```
