### PR TITLE
fcgx-puts() has wrong utf-8 content length

### DIFF
--- a/cl-fastcgi-x.lisp
+++ b/cl-fastcgi-x.lisp
@@ -55,7 +55,10 @@
     (macrolet ((cputs (type pointer)
                   `(foreign-funcall "FCGX_PutStr"
                                     ,type ,pointer
-                                    :int (length content)
+                                    :int #+sbcl (length (sb-ext:string-to-octets content))
+                                         #+ccl (ccl:string-size-in-octets content)
+                                         #+clisp (length (convert-string-to-bytes content))
+                                         #-(or sbcl ccl clisp) (babel:string-size-in-octets content)
                                     :pointer ostr
                                     :int)))
       (etypecase content

--- a/cl-fastcgi.asd
+++ b/cl-fastcgi.asd
@@ -14,7 +14,9 @@
   :depends-on (#:usocket
                #:cffi
                #+sbcl
-               #:sb-bsd-sockets)
+               #:sb-bsd-sockets
+               #-(or sbcl ccl clisp) 
+               #:babel)
   :serial t
   :components ((:file "package")
                (:file "cl-fastcgi")

--- a/package.lisp
+++ b/package.lisp
@@ -8,7 +8,8 @@
 
 
 (defpackage #:cl-fastcgi
-  (:use :cl :cffi)
+  (:use :cl :cffi
+        #-(or sbcl ccl clisp) :babel)
   (:export #:load-libfcgi
            ;;internal
            #:fcgx-init


### PR DESCRIPTION
… problem, but if utf-8, such as Japanese, is specified in the string, garbled characters will occur.

When calling libfcgi's FCGX_PutStr() from fcgx-puts, the length of the string obtained from the passed content is calculated with the length function, but to output strings containing utf-8, the buffer length must be passed as a byte string.

Note that this change is only checked for utf-8, so further consideration may be needed if other external encodings are supported.

---- testing code ----

(ql:quickload :flexi-streams)

(ql:quickload :cl-fastcgi)

(defun simple-app (req))
  (let ((c (format nil "Content-Type: text/plain; charset=utf-8

Hello, I am a fcgi-program using Common-Lisp
~%~A~%"
                   (cl-fastcgi:fcgx-getenv req))))
    (cl-fastcgi:fcgx-puts req c)
    (cl-fastcgi:fcgx-puts req "abcdef")
    (cl-fastcgi:fcgx-puts req "あいうえお"))
    ))

(cl-fastcgi:socket-server #'simple-app :inet-addr "0.0.0.0" :port 9045)) ---- testing code ----