### PR TITLE
Fix type consistency problem.

### DIFF
--- a/cl-fastcgi-x.lisp
+++ b/cl-fastcgi-x.lisp
@@ -52,21 +52,19 @@
       ((eql stream :err)
        (setf ostr (foreign-slot-value req 'fcgx-request 'err)))
       (t (setf ostr (foreign-slot-value req 'fcgx-request 'out))))
-    (macrolet ((cputs (type pointer)
-                  `(foreign-funcall "FCGX_PutStr"
-                                    ,type ,pointer
-                                    :int #+sbcl (length (sb-ext:string-to-octets content))
-                                         #+ccl (ccl:string-size-in-octets content)
-                                         #+clisp (length (convert-string-to-bytes content))
-                                         #-(or sbcl ccl clisp) (babel:string-size-in-octets content)
-                                    :pointer ostr
-                                    :int)))
-      (etypecase content
-        ((vector (unsigned-byte 8)) (with-pointer-to-vector-data (p content)
-                                      (cputs :pointer p)))
-        ;; Let foreign-funcall try to convert any non-vector to a :string
-        (T (cputs :string content))))))
-
+    (etypecase content
+      ((vector (unsigned-byte 8))
+       (with-pointer-to-vector-data (p content)
+         (foreign-funcall "FCGX_PutStr" :pointer p :int (length content) :pointer ostr :int)))
+      ;; Let foreign-funcall try to convert any non-vector to a string.
+      (T (foreign-funcall "FCGX_PutStr"
+                          :string content
+                          :int #+sbcl (length (sb-ext:string-to-octets content))
+                               #+ccl (ccl:string-size-in-octets content)
+                               #+clisp (length (convert-string-to-bytes content))
+                               #-(or sbcl ccl clisp) (babel:string-size-in-octets content)
+                          :pointer ostr
+                          :int)))))
 
 ;;TODO : make these bufffers thread-local?
 (defun fcgx-read (req)


### PR DESCRIPTION
The previous change introduced a type error.  The cputs macro previously was able to handle both vectors and strings, but the change broke that.  Delete the macro and handle vectors and strings with different code.