### PR TITLE
Modify FCGX-PUTS to handle octet vectors

### DIFF
--- a/cl-fastcgi-x.lisp
+++ b/cl-fastcgi-x.lisp
@@ -52,20 +52,23 @@
       ((eql stream :err)
        (setf ostr (foreign-slot-value req 'fcgx-request 'err)))
       (t (setf ostr (foreign-slot-value req 'fcgx-request 'out))))
-    (macrolet ((cputs (type pointer)
-                  `(foreign-funcall "FCGX_PutStr"
-                                    ,type ,pointer
-                                    :int #+sbcl (length (sb-ext:string-to-octets content))
-                                         #+ccl (ccl:string-size-in-octets content)
-                                         #+clisp (length (convert-string-to-bytes content))
-                                         #-(or sbcl ccl clisp) (babel:string-size-in-octets content)
-                                    :pointer ostr
-                                    :int)))
-      (etypecase content
-        ((vector (unsigned-byte 8)) (with-pointer-to-vector-data (p content)
-                                      (cputs :pointer p)))
-        ;; Let foreign-funcall try to convert any non-vector to a :string
-        (T (cputs :string content))))))
+    (etypecase content
+      ((vector (unsigned-byte 8))
+       (with-pointer-to-vector-data (p content)
+         (foreign-funcall "FCGX_PutStr"
+                          :pointer p
+                          :int (length content)
+                          :pointer ostr
+                          :int)))
+      ;; Let foreign-funcall try to convert any non-vector to a :string
+      (T (foreign-funcall "FCGX_PutStr"
+                          :string content
+                          :int #+sbcl (length (sb-ext:string-to-octets content))
+                               #+ccl (ccl:string-size-in-octets content)
+                               #+clisp (length (convert-string-to-bytes content))
+                               #-(or sbcl ccl clisp) (babel:string-size-in-octets content)
+                          :pointer ostr
+                          :int)))))
 
 
 ;;TODO : make these bufffers thread-local?


### PR DESCRIPTION
I noticed in `FCGX-PUTS` there was code in place that seemed to be designed to handle octet vectors as well as strings.  However, there was a bug where `SB-EXT:STRING-TO-OCTETS` (or equivalent for other implementations) would be called on the given octet vector and cause an error every time.

I have an alternate version I could update this request with that introduces a separate `FCGX-PUT-OCTETS` function rather than conditionalizing `FCGX-PUTS`, if you would prefer.

Companion change in SB-FastCGI: https://github.com/KDr2/sb-fastcgi/pull/3